### PR TITLE
Rename Project to Go Starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Starter Go
+# Go Starter
 
-A minimalistic [Go](https://go.dev/) template to kickstart your project.
+A minimalistic [GitHub repository template](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template) to kickstart your [Go](https://go.dev/) project

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/threeal/starter-go
+module github.com/threeal/go-starter
 
 go 1.19
 


### PR DESCRIPTION
This pull request resolves #16 by renaming the project in the `go.mod` and `README.md` files.