### PR TITLE
Add `.gitattributes` File

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+go.sum -diff linguist-generated


### PR DESCRIPTION
This pull request resolves #20 by adding a `.gitattributes` file that disable diff and set generated attribute to the `go.sum` file.