### PR TITLE
Utilize Setup Go Action in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.2
 
+      - name: Setup Go
+        uses: actions/setup-go@v5.0.0
+        with:
+          go-version: stable
+
       - name: Check Formatting
         run: |
           go fmt ./...
@@ -23,6 +28,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.2
+
+      - name: Setup Go
+        uses: actions/setup-go@v5.0.0
+        with:
+          go-version: stable
 
       - name: Run Tests
         run: go test -v ./...


### PR DESCRIPTION
This pull request resolves #24 by utilizing the [Setup Go](https://github.com/marketplace/actions/setup-go-environment) action to set up Go to the latest stable version.