### PR TITLE
Check for Test Coverage in CI Workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,4 +35,12 @@ jobs:
           go-version: stable
 
       - name: Run Tests
-        run: go test -v ./...
+        run: go test -v ./... -coverprofile=.cover.out -covermode=atomic -coverpkg=./...
+
+      - name: Check Coverage
+        uses: vladopajic/go-test-coverage@v2.9.0
+        with:
+          profile: .cover.out
+          threshold-file: 100
+          threshold-package: 100
+          threshold-total: 100


### PR DESCRIPTION
This pull request resolves #26 by adding a step in the `test-packages` job for checking test coverage using the [vladopajic/go-test-coverage](https://github.com/vladopajic/go-test-coverage) action.