### PR TITLE
Bump Go to Version 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/threeal/go-starter
 
-go 1.19
+go 1.22
 
 require github.com/stretchr/testify v1.9.0
 


### PR DESCRIPTION
This pull request simply bumps Go to version [1.22](https://tip.golang.org/doc/go1.22). Using the latest Go version is proposed to enable this template to utilize the newest available features in Go.