### PR TITLE
Separate CI Workflow

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,0 +1,23 @@
+name: Check
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  check-packages:
+    name: Check Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out
+        uses: actions/checkout@v4.1.7
+
+      - name: Setup Go
+        uses: actions/setup-go@v5.0.1
+        with:
+          go-version: stable
+
+      - name: Check Formatting
+        run: |
+          go fmt ./...
+          git diff --exit-code HEAD

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,32 +1,15 @@
-name: CI
+name: Test
 on:
   workflow_dispatch:
   pull_request:
   push:
     branches: [main]
 jobs:
-  check-packages:
-    name: Check Packages
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.7
-
-      - name: Setup Go
-        uses: actions/setup-go@v5.0.1
-        with:
-          go-version: stable
-
-      - name: Check Formatting
-        run: |
-          go fmt ./...
-          git diff --exit-code HEAD
-
   test-packages:
     name: Test Packages
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Check Out
         uses: actions/checkout@v4.1.7
 
       - name: Setup Go


### PR DESCRIPTION
This pull request resolves #37 by separating the `ci` workflow into `check` and `test` workflows.