### PR TITLE
Set Up Go Version in Workflow Based on `go.mod`

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -12,10 +12,10 @@ jobs:
       - name: Check Out
         uses: actions/checkout@v4.1.7
 
-      - name: Setup Go
+      - name: Set Up Go
         uses: actions/setup-go@v5.0.1
         with:
-          go-version: stable
+          go-version-file: go.mod
 
       - name: Check Formatting
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,10 +12,10 @@ jobs:
       - name: Check Out
         uses: actions/checkout@v4.1.7
 
-      - name: Setup Go
+      - name: Set Up Go
         uses: actions/setup-go@v5.0.1
         with:
-          go-version: stable
+          go-version-file: go.mod
 
       - name: Run Tests
         run: go test -v ./... -coverprofile=.cover.out -covermode=atomic -coverpkg=./...


### PR DESCRIPTION
This pull request resolves #41 by setting up Go in the workflow with the version specified in the `go.mod`.