### PR TITLE
Specify Runner OS Version in Workflows

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   check-packages:
     name: Check Packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check Out
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   test-packages:
     name: Test Packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check Out
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
This pull request resolves #54 by manually specifying the runner OS version to be used in workflows, replacing the default latest version.