### PR TITLE
Bump Go to Version 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/threeal/go-starter
 
-go 1.22
+go 1.23
 
 require github.com/stretchr/testify v1.9.0
 


### PR DESCRIPTION
This pull request updates the Go version specified in the `go.mod` file to [1.23](https://tip.golang.org/doc/go1.23).